### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,18 +25,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*.d.ts"
-      ]
-    }
   },
   "scripts": {
     "build": "rimraf dist && tsc",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "src/antelope.test.ts"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2"
+    "@antelopejs/interface-core": "^0.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.2
@@ -48,8 +48,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -502,6 +502,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1172,7 +1175,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
       reflect-metadata: 0.2.2
 
@@ -1489,7 +1492,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1611,6 +1614,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -1690,7 +1695,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Remove wildcard subpath exports (`./*` and `typesVersions` wildcard) to hide internal dist paths from consumers
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This maintenance PR removes wildcard subpath exports (`./*` and `typesVersions` wildcard) from `package.json` to prevent consumers from importing arbitrary internal `dist/` paths, and bumps the `@antelopejs/interface-core` dependency from `^0.0.2` to `^0.0.3`. The lock file is updated accordingly, including a transitive `defu` version bump from `6.1.4` to `6.1.7`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a straightforward package maintenance change with no logic modifications.

Both changes are intentional and well-described: removing wildcard exports is a deliberate encapsulation improvement (package is still pre-1.0), and the dependency bump is a patch-level update. No logic, runtime behaviour, or public API surface is altered beyond the intentional removal of internal path re-exports.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard subpath exports and typesVersions wildcard to restrict consumer access to internal dist paths; bumps @antelopejs/interface-core from ^0.0.2 to ^0.0.3 |
| pnpm-lock.yaml | Lock file updated to reflect @antelopejs/interface-core@0.0.3 and a transitive defu bump from 6.1.4 to 6.1.7 in some snapshots |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer imports package] --> B{Export path?}
    B -->|"."| C["✅ ./dist/index.js\n(main entry)"]
    B -->|"./package.json"| D["✅ ./package.json"]
    B -->|"./* (removed)"| E["❌ No longer exposed\n(internal dist paths hidden)"]

    style C fill:#d4edda,stroke:#28a745
    style D fill:#d4edda,stroke:#28a745
    style E fill:#f8d7da,stroke:#dc3545
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-api/commit/2e770c85008cbf09b0234eaac864b92792155198) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29166777)</sub>

<!-- /greptile_comment -->