### PR TITLE
feat(cors): expose gettable and settable CORS config in interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,6 +522,54 @@ export const GetControllerInstance: <T>(
 export const Listen: () => Promise<void> = InterfaceFunction();
 
 /**
+ * Allowed CORS origin.
+ *
+ * Either a single origin (exact string or RegExp) or a list of origins.
+ */
+export type AllowedOrigin = string | RegExp | Array<string | RegExp>;
+
+/**
+ * CORS configuration.
+ */
+export interface CorsConfig {
+  /**
+   * Origins allowed to access the API. CORS is disabled when omitted.
+   */
+  allowedOrigins?: AllowedOrigin;
+
+  /**
+   * HTTP methods allowed for cross-origin requests.
+   */
+  allowedMethods?: string[];
+
+  /**
+   * Whether to send the Access-Control-Allow-Credentials header.
+   */
+  credentials?: boolean;
+
+  /**
+   * Lifetime in seconds of the preflight response (Access-Control-Max-Age).
+   */
+  maxAge?: number;
+}
+
+/**
+ * Returns the current CORS configuration.
+ *
+ * @returns Current CORS configuration.
+ */
+export const GetCorsConfig: () => Promise<CorsConfig> = InterfaceFunction();
+
+/**
+ * Replaces the CORS configuration. Changes apply to subsequent requests
+ * without restarting the servers.
+ *
+ * @param config New CORS configuration.
+ */
+export const SetCorsConfig: (config: CorsConfig) => Promise<void> =
+  InterfaceFunction();
+
+/**
  * Handler mode.
  */
 export type RouteHandlerMode =

--- a/src/index.ts
+++ b/src/index.ts
@@ -543,6 +543,13 @@ export interface CorsConfig {
   allowedMethods?: string[];
 
   /**
+   * Request headers allowed for cross-origin requests
+   * (Access-Control-Allow-Headers). When omitted, the implementation
+   * reflects the headers requested by the client.
+   */
+  allowedHeaders?: string[];
+
+  /**
    * Whether to send the Access-Control-Allow-Credentials header.
    */
   credentials?: boolean;


### PR DESCRIPTION
## Summary

Adds the ability to **read** and **update** the CORS configuration at runtime through the `interface-api` contract, without restarting the servers. The concrete implementation will be provided by the `@antelopejs/api` module (to follow in a separate PR).

## Changes (`src/index.ts`)

- **`AllowedOrigin`** — exported type (`string | RegExp | Array<string | RegExp>`).
- **`CorsConfig`** — contract interface, extended with `allowedHeaders?`, `credentials?` and `maxAge?` in addition to `allowedOrigins` / `allowedMethods`.
- **`GetCorsConfig: () => Promise<CorsConfig>`** and **`SetCorsConfig: (config) => Promise<void>`** — declared via `InterfaceFunction()`, following the same pattern as `Listen` and `GetControllerInstance`.

## Notes

- The signatures are asynchronous to stay consistent with the rest of the `InterfaceFunction` contract (all interface functions return `Promise`).
- On the implementation side (`api` module, not included here): the CORS middleware re-reads the config on every request, so `SetCorsConfig` takes effect immediately via a mutation of `conf.cors`.

## Checks

- `pnpm run lint` ✅
- `pnpm run build` ✅