### PR TITLE
chore(deps): interface-core as wide peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,8 @@
   "antelopeJs": {
     "test": "src/antelope.test.ts"
   },
-  "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3"
-  },
   "devDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.19.15",
@@ -54,6 +52,9 @@
     "sinon": "^20.0.0",
     "typescript": "^5.9.3",
     "ws": "^8.20.0"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,10 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
     devDependencies:
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2


### PR DESCRIPTION
## What
Move `@antelopejs/interface-core` from `dependencies` to `peerDependencies` with a wide `>=0.0.5` range.

## Why
`interface-core` is a runtime singleton — the host runtime provides a single instance and redirects all `@antelopejs/interface-core` imports to it. Declaring it as a regular dependency with a tight `^0.0.x` caret (which, for 0.0.z, resolves to that exact patch) forces dual installs and version-pinning overrides in consumers (e.g. the cms). A wide peer range lets the consumer-provided version satisfy it, eliminating that friction.

## Verification
- `pnpm install` resolves interface-core 0.0.5 via autoInstallPeers
- `pnpm build` ✅
- `pnpm lint` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `@antelopejs/interface-core` from `dependencies` to `peerDependencies` to avoid duplicate installs when the host runtime provides a singleton instance, and adds a bounded `>=0.0.3 <1.0.0` range to prevent silent breakage from pre-1.0 incompatible releases.

- `devDependencies` now mirrors the peer range so contributors always have a usable local install, regardless of `autoInstallPeers` settings.
- `peerDependencies` uses `>=0.0.3 <1.0.0` (bounded) instead of the open-ended range described in the PR description (`>=0.0.5`); the lockfile is consistent with these changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly restructures the dependency declaration without altering any runtime logic.

The only changes are in package.json and pnpm-lock.yaml. Moving interface-core to peerDependencies with a bounded <1.0.0 upper limit is the right approach for a runtime singleton, and the mirrored devDependencies entry ensures local builds work reliably. No source code is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves @antelopejs/interface-core from dependencies to peerDependencies with bounded range >=0.0.3 <1.0.0, and mirrors it in devDependencies for local development |
| pnpm-lock.yaml | Lockfile reflects move of @antelopejs/interface-core from dependencies to devDependencies with updated specifier |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer App] -->|provides| B[interface-core singleton]
    A -->|installs| C[interface-api]
    C -->|peerDependency range| B
    C -->|devDependency for local dev| D[local install]
    B -->|resolved once and shared| C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Consumer App] -->|provides| B[interface-core singleton]
    A -->|installs| C[interface-api]
    C -->|peerDependency range| B
    C -->|devDependency for local dev| D[local install]
    B -->|resolved once and shared| C
```

</a>

<sub>Reviews (4): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-api/commit/411b08f82f56f5343f8dee14696f3fa36bf0e370) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37728905)</sub>

<!-- /greptile_comment -->